### PR TITLE
Adopt UIGlassEffect for the HUD on iOS 26

### DIFF
--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -1354,55 +1354,60 @@ static const CGFloat SVProgressHUDLabelSpacing = 8.0f;
 }
     
 - (void)fadeInEffects {
-    if(self.defaultStyle != SVProgressHUDStyleCustom) {
-        // Add blur effect
-        UIBlurEffectStyle blurEffectStyle = self.defaultStyle == SVProgressHUDStyleDark ? UIBlurEffectStyleDark : UIBlurEffectStyleLight;
-        CGFloat backgroundAlpha = 0.6f;
-        UIVisualEffect *visualEffect = nil;
+    BOOL usesCustomStyle = self.defaultStyle == SVProgressHUDStyleCustom;
+    UIVisualEffect *visualEffect = nil;
+    CGFloat backgroundAlpha = 0.6f;
+    UIBlurEffectStyle blurEffectStyle = UIBlurEffectStyleLight;
+    if (!usesCustomStyle && self.defaultStyle == SVProgressHUDStyleDark) {
+        blurEffectStyle = UIBlurEffectStyleDark;
+    }
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
-        if (@available(iOS 13.0, *)) {
-            NSProcessInfo *processInfo = NSProcessInfo.processInfo;
-            NSOperatingSystemVersion iOS26Version = (NSOperatingSystemVersion){26, 0, 0};
-            if ([processInfo isOperatingSystemAtLeastVersion:iOS26Version]) {
-                // Prefer the dedicated glass material introduced with iOS 26 when available.
-                Class glassEffectClass = NSClassFromString(@"UIGlassEffect");
-                if (glassEffectClass) {
-                    id glassEffect = [[glassEffectClass alloc] init];
-                    if (glassEffect && [glassEffect isKindOfClass:[UIVisualEffect class]]) {
-                        SEL interactiveSelector = NSSelectorFromString(@"setInteractive:");
-                        if ([glassEffect respondsToSelector:interactiveSelector]) {
-                            IMP imp = [glassEffect methodForSelector:interactiveSelector];
-                            void (*setInteractive)(id, SEL, BOOL) = (void (*)(id, SEL, BOOL))imp;
-                            if (setInteractive != NULL) {
-                                setInteractive(glassEffect, interactiveSelector, YES);
-                            }
+    if (@available(iOS 13.0, *)) {
+        NSProcessInfo *processInfo = NSProcessInfo.processInfo;
+        NSOperatingSystemVersion iOS26Version = (NSOperatingSystemVersion){26, 0, 0};
+        if ([processInfo isOperatingSystemAtLeastVersion:iOS26Version]) {
+            // Prefer the dedicated glass material introduced with iOS 26 when available.
+            Class glassEffectClass = NSClassFromString(@"UIGlassEffect");
+            if (glassEffectClass) {
+                id glassEffect = [[glassEffectClass alloc] init];
+                if (glassEffect && [glassEffect isKindOfClass:[UIVisualEffect class]]) {
+                    SEL interactiveSelector = NSSelectorFromString(@"setInteractive:");
+                    if ([glassEffect respondsToSelector:interactiveSelector]) {
+                        IMP imp = [glassEffect methodForSelector:interactiveSelector];
+                        void (*setInteractive)(id, SEL, BOOL) = (void (*)(id, SEL, BOOL))imp;
+                        if (setInteractive != NULL) {
+                            setInteractive(glassEffect, interactiveSelector, YES);
                         }
-                        visualEffect = glassEffect;
+                    }
+                    visualEffect = glassEffect;
+                    if (!usesCustomStyle) {
                         backgroundAlpha = 0.0f;
                     }
                 }
             }
-            if (!visualEffect) {
-                if (self.defaultStyle == SVProgressHUDStyleDark) {
-                    blurEffectStyle = UIBlurEffectStyleSystemChromeMaterialDark;
-                } else {
-                    blurEffectStyle = UIBlurEffectStyleSystemChromeMaterialLight;
-                }
+        }
+        if (!visualEffect && !usesCustomStyle) {
+            if (self.defaultStyle == SVProgressHUDStyleDark) {
+                blurEffectStyle = UIBlurEffectStyleSystemChromeMaterialDark;
+            } else {
+                blurEffectStyle = UIBlurEffectStyleSystemChromeMaterialLight;
             }
         }
+    }
 #endif
-        if (!visualEffect) {
-            visualEffect = [UIBlurEffect effectWithStyle:blurEffectStyle];
-        }
-        self.hudView.effect = visualEffect;
+    if (!visualEffect && !usesCustomStyle) {
+        visualEffect = [UIBlurEffect effectWithStyle:blurEffectStyle];
+    }
+    self.hudView.effect = visualEffect;
 
-        // We omit UIVibrancy effect and use a suitable background color as an alternative.
-        // This will make everything more readable. See the following for details:
-        // https://www.omnigroup.com/developer/how-to-make-text-in-a-uivisualeffectview-readable-on-any-background
+    // We omit UIVibrancy effect and use a suitable background color as an alternative.
+    // This will make everything more readable. See the following for details:
+    // https://www.omnigroup.com/developer/how-to-make-text-in-a-uivisualeffectview-readable-on-any-background
 
+    if (!usesCustomStyle) {
         self.hudView.backgroundColor = [self.backgroundColorForStyle colorWithAlphaComponent:backgroundAlpha];
     } else {
-        self.hudView.backgroundColor =  self.backgroundColorForStyle;
+        self.hudView.backgroundColor = self.backgroundColorForStyle;
     }
 
     // Fade in views
@@ -1416,10 +1421,8 @@ static const CGFloat SVProgressHUDLabelSpacing = 8.0f;
 
 - (void)fadeOutEffects
 {
-    if(self.defaultStyle != SVProgressHUDStyleCustom) {
-        // Remove blur effect
-        self.hudView.effect = nil;
-    }
+    // Remove blur or glass effect
+    self.hudView.effect = nil;
 
     // Remove background color
     self.hudView.backgroundColor = [UIColor clearColor];


### PR DESCRIPTION
## Summary
- dynamically instantiate UIGlassEffect on iOS 26 so the HUD background uses the new glass material
- set the effect as interactive while leaving the chrome blur fallback for earlier systems
- import objc runtime utilities to safely toggle the glass effect at runtime

## Testing
- not run (xcodebuild unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_b_68c87dabd68c8322922833d70d59a545